### PR TITLE
Sketch of a leader lock

### DIFF
--- a/lib/lita/external/cli.rb
+++ b/lib/lita/external/cli.rb
@@ -53,6 +53,7 @@ module Lita
         load_lita_config(options)
         set_adapter(options)
         robot = Lita::External::Robot.new
+        robot.initialize_leader_lock
         p robot.send(:adapter)
         robot.run
         0

--- a/lita-external.gemspec
+++ b/lita-external.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'lita', '~> 4.6'
+  spec.add_dependency 'zk', '~> 1.9.6'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
@byroot here's a little POC of a lock that would allow us to run multiple `lita-external` processes: e.g. one in each of CHI2 and ASH.  This would give us automatic failover as both instances would receive Slack messages but only one would enqueue and respond.  I think webhooks could be safely dispatched to either DC and health-checked via Dyn Traffic Manager like we do for Locutus failovers.

It uses a simple non-blocking Zookeeper lock, and `ZOOKEEPER_PEERS` and `ENV` variables to control the initialization.  I don't love this technique but it seems simpler than messing around with Lita's `Configurable` mess.

thoughts?

 