### PR TITLE
Add a master_receive event that allows veto of delivery

### DIFF
--- a/lib/lita/external/robot.rb
+++ b/lib/lita/external/robot.rb
@@ -1,9 +1,23 @@
 module Lita
   module External
     class Robot < ::Lita::Robot
+
+      class Ballot
+        attr_accessor :veto
+        def initialize
+          @veto = false
+        end
+      end
+
       def receive(message)
-        Lita.logger.debug("Put inbound message from #{message.user.mention_name} into the queue")
-        Lita.redis.rpush('messages:inbound', External.dump_message(message))
+        ballot = Ballot.new
+        trigger(:master_receive, ballot: ballot)
+        if ballot.veto
+          Lita.logger.debug("Ignoring vetoed message")
+        else
+          Lita.logger.debug("Put inbound message from #{message.user.mention_name} into the queue")
+          Lita.redis.rpush('messages:inbound', External.dump_message(message))
+        end
       end
 
       def run

--- a/lib/lita/external/version.rb
+++ b/lib/lita/external/version.rb
@@ -1,5 +1,5 @@
 module Lita
   module External
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Provides an event that handlers can use to prevent a message from being handled.  It passes a `Ballot` instance to potentially many handlers, if any of them mark it as `veto=true` the message is dropped and logged when in debug mode.

This is scaffolding to allow multiple Spy instances to run simultaneously and constrain processing to a chosen master (details of leadership selection are abstracted out).

r: @byroot 