### PR TITLE
Call the adapter run method with a block to be called when it's ready

### DIFF
--- a/lib/lita/external/robot.rb
+++ b/lib/lita/external/robot.rb
@@ -1,5 +1,14 @@
 module Lita
   module External
+    class ::Lita::Robot
+      def run(&block)
+        run_app
+        adapter.run(&block)
+      rescue Interrupt
+        shut_down
+      end
+    end
+
     class Robot < ::Lita::Robot
       CommandFailed = Class.new(StandardError)
 
@@ -26,8 +35,9 @@ module Lita
 
         trigger(:master_loaded)
 
-        watch_outbound_queue
-        super
+        super do
+          watch_outbound_queue
+        end
       end
 
       def shut_down


### PR DESCRIPTION
Overrides `::Lita::Robot.run` so that it can take a block that can be yielded once the websocket is connected.

Related code: https://github.com/Shopify/lita-slack/pull/14, https://github.com/Shopify/lita-slack/pull/18, https://github.com/Shopify/lita-slack/pull/21.